### PR TITLE
Add Authentication Module: Crowd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class sonar (
   $user_system = true,
   $service = 'sonar', $installroot = '/usr/local', $home = '/var/local/sonar',
   $port = 9000, $download_url = 'http://dist.sonar.codehaus.org', 
-  $context_path = '/', $arch = '', $ldap = {},
+  $context_path = '/', $arch = '', $ldap = {}, $crowd = {},
   $jdbc = {
     url               => 'jdbc:derby://localhost:1527/sonar;create=true',
     driver_class_name => 'org.apache.derby.jdbc.ClientDriver',
@@ -131,6 +131,13 @@ class sonar (
   sonar::plugin { 'sonar-ldap-plugin' :
     ensure     => empty($ldap) ? {true => absent, false => present},
     artifactid => 'sonar-ldap-plugin',
+    version    => '1.0',
+    notify     => Service[$service],
+  } ->
+
+  sonar::plugin { 'sonar-crowd-plugin' :
+    ensure     => empty($crowd) ? {true => absent, false => present},
+    artifactid => 'sonar-crowd-plugin',
     version    => '1.0',
     notify     => Service[$service],
   } ->

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -210,3 +210,34 @@ ldap.bindPassword: <%=ldap['bind_password']%>
 # Default is 'com.sun.jndi.ldap.LdapCtxFactory'.
 #ldap.contextFactoryClass: com.sun.jndi.ldap.LdapCtxFactory
 <% end %>
+
+<% if !crowd.empty? %>
+#-------------------
+# Sonar Crowd Plugin
+#-------------------
+# IMPORTANT : before activation, make sure that one Sonar administrator is defined in the external system
+# Activates the plugin. Leave blank or comment out to use default sonar authentication.
+sonar.authenticator.class: org.sonar.plugins.crowd.CrowdAuthenticator
+
+# Ignore failure at startup if the connection to external system is refused.
+# Users can browse sonar but not log in as long as the connection fails.
+# When set to true, Sonar will not start if connection to external system fails.
+# Default is false.
+#sonar.authenticator.ignoreStartupFailure: true
+
+# Automatically create users (available since Sonar 2.0).
+# When set to true, user will be created after successful authentication, if doesn't exists.
+# The default group affected to new users can be defined online, in Sonar general settings. The default value is "sonar-users".
+# Default is false.
+sonar.authenticator.createUsers: true
+
+# URL of the Crowd server (usually ends with /services/).
+crowd.url: <%=crowd['service_url']%>
+
+# Crowd application name.
+# Default is 'sonar'.
+crowd.application: <%=crowd['application']%>
+
+# Crowd application password.
+crowd.password: <%=crowd['password']%>
+<% end %>

--- a/templates/sonar.sh.erb
+++ b/templates/sonar.sh.erb
@@ -1,5 +1,15 @@
 #! /bin/sh
 
+### BEGIN INIT INFO
+# Provides:          sonar
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Sonar
+# Description:       Sonar Software Quality Management
+### END INIT INFO
+
 #
 # Copyright (c) 1999, 2006 Tanuki Software Inc.
 #


### PR DESCRIPTION
This patch adds support for [Atlassian Crowd](http://www.atlassian.com/software/crowd/) as an authentication provider. 

Missing LSB headers have also been added since Debian Squeeze and upwards refuse to add the startup script without them.
