### PR TITLE
facter can produce architecture = amd64 and this causes the wrong binary to be selected

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class sonar (
   if $arch1 != 'macosx' {
     $arch2 = $::architecture ? {
       'x86_64' => 'x86-64',
+      'amd64'  => 'x86-64',
       default  => 'x86-32',
     }
   } else {


### PR DESCRIPTION
This pull request fixes that.

Signed-off-by: Daniel Thomas drt24@cam.ac.uk
